### PR TITLE
unresolved questions consistency

### DIFF
--- a/app/views/current/task-list.html
+++ b/app/views/current/task-list.html
@@ -331,26 +331,26 @@
                 <a href="questions-claimant" id="questions">
                 The claimant
                 </a>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="list-convictions-status">1 open questions</strong>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="list-convictions-status">unresolved questions</strong>
                </li>
             <li class="app-task-list__item">
                 <a href="questions-doctor" >
                 The claimant's doctor
                 </a>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="list-convictions-status">2 open questions</strong>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="list-convictions-status">unresolved questions</strong>
                </li>
 
             <li class="app-task-list__item">
               <a href="questions-urologist" >
                 The claimant's urologist
                 </a>
-               <strong class="govuk-tag app-task-list__tag" id="list-convictions-status">all questions answered</strong>
+               <strong class="govuk-tag app-task-list__tag" id="list-convictions-status">all questions resolved</strong>
             </li>
             <li class="app-task-list__item">
               <a href="questions-consultant" >
                 The claimant's consultant
                 </a>
-               <strong class="govuk-tag app-task-list__tag" id="list-convictions-status">all questions answered</strong>
+               <strong class="govuk-tag app-task-list__tag" id="list-convictions-status">all questions resolved</strong>
             </li>
       </ol>
 


### PR DESCRIPTION
changing the flags on the case details page to match the questions pages as it easier for now.

on the claimants question page we have 'unresolved questions' and 'resolved questions'
but on the case details page we have flags that say '1 open question' and '1 question answered.'